### PR TITLE
Updated packages and old React Pre-hooks code to modern syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A simple react HOC component to render child components in PNG.
 
 This can be useful for various reasons:
+
 - Allowing for elements created within a React page to be easily copied and shared in official company documents such as Word, Excel, etc.
 - Allow for items generated online to be easily copied for later reference.
 
@@ -29,12 +30,12 @@ import RenderAsImage, { IRenderAsImageProps } from 'react-render-as-image'
 To render React components as an image include the components as children of the RenderAsImage component as illustrated below:
 
 ```
-<ImageAsHtml height="500" alt="Hello World!">
+<RenderAsImage height="500" alt="Hello World!">
     <div>Hello World!</div>
-</ImageAsHtml>
+</RenderAsImage>
 ```
 
-NOTE: ImageAsHTML will only render the first child node - as such if you have multiple child nodes it will be necessary to enclose them in a containing div element.
+NOTE: RenderAsImage will only render the first child node - as such if you have multiple child nodes it will be necessary to enclose them in a containing div element.
 
 ## Available props
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "1.0.0",
   "description": "Render React child components as an image.",
   "main": "dist/index.js",
-  "scripts": {
-    "build": "rollup -c",
-    "start": "rollup -c -w"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alanwolman/react-render-as-image.git"
@@ -26,17 +22,24 @@
     "url": "https://github.com/alanwolman/react-render-as-image/issues"
   },
   "homepage": "https://github.com/alanwolman/react-render-as-image#readme",
+  "scripts": {
+    "build": "rollup -c",
+    "start": "rollup -c -w"
+  },
+  "dependencies": {
+    "html-to-image": "^1.10.8"
+  },
   "devDependencies": {
-    "@types/react": "^16.9.35",
-    "@types/react-dom": "^16.9.8",
+    "@types/react": "^18.0.25",
+    "@types/react-dom": "^18.0.8",
     "babel-core": "^6.26.3",
     "babel-runtime": "^6.26.0",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "rollup": "^2.10.5",
-    "rollup-plugin-sass": "^1.2.2",
-    "rollup-plugin-typescript2": "^0.27.1",
-    "typescript": "^3.9.2"
+    "react-dom": "^18.2.0",
+    "rollup": "^3.3.0",
+    "rollup-plugin-sass": "^1.12.16",
+    "rollup-plugin-typescript2": "^0.34.1",
+    "typescript": "^4.8.4"
   },
   "peerDependencies": {
     "react": "^16.8.0",
@@ -44,8 +47,5 @@
   },
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "html-to-image": "^0.1.1"
-  }
+  ]
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,39 +1,39 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import './styles.scss';
-import htmlToImage from 'html-to-image';
+import { toPng } from "html-to-image";
+import * as React from "react";
 
 export type IRenderAsImageProps = {
-  children: React.ReactNode,
-  width?: number | string,
-  height?: number | string,
-  alt?: string
+  children: React.ReactNode;
+  width?: number | string;
+  height?: number | string;
+  alt?: string;
+};
+
+export default function RenderAsImage({
+  children,
+  width,
+  height,
+  alt,
+}: IRenderAsImageProps) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [imgSrc, setImgSrc] = React.useState("");
+
+  React.useEffect(() => {
+    toPng(ref.current!)
+      .then(function (dataUrl) {
+        setImgSrc(dataUrl);
+      })
+      .catch(function (error) {
+        console.error("oops, something went wrong!", error);
+      });
+  }, []);
+
+  return (
+    <>
+      {imgSrc !== "" ? (
+        <img src={imgSrc} height={height} width={width} alt={alt} />
+      ) : (
+        <div ref={ref}>{children}</div>
+      )}
+    </>
+  );
 }
-
-const initialState = { imageDataUrl: '' };
-type State = Readonly<typeof initialState>;
-
-class RenderAsImage extends React.Component<IRenderAsImageProps> {
-    private myDiv: HTMLDivElement | null;
-    readonly state: State = initialState;
-
-    componentDidMount = () => {
-      if (this.myDiv) {
-        htmlToImage.toPng(ReactDOM.findDOMNode(this.myDiv.firstElementChild) as HTMLElement)
-        .then(
-            (dataUrl) => {
-              this.setState({...this.state, imageDataUrl: dataUrl });
-            }
-        );
-      }
-    }
-
-    render = () => {
-      
-      return (this.state.imageDataUrl !== '')
-                ?  <img src={this.state.imageDataUrl} height={this.props.height} width={this.props.height} alt={this.props.alt}/> 
-                : <div ref={c => this.myDiv = c} ><div>{this.props.children}</div></div>;
-    }
-  };
-
-export default RenderAsImage;


### PR DESCRIPTION
I found this package and when I tried to use it didn't work. After cloning and trying to npm install, one of the packages failed to install, probably because it was obsolete. 
This package is a super clean way to turn HTML elements into Images in React, so I decided to give it some very deserved love.
Firstly I updated the package.json to the current newest versions of dependencies. After that, I refactored the code to the modern React syntax with hooks. 
I also fixed a typing error on the Readme file that confused me when I tried to use the package first.
It's currently working for me, so I hope this helps some other people.

Note: Regarding the issue: https://github.com/alanwolman/react-render-as-image/issues/5 I am getting the same bug, especially if I have actual images inside my div element.  Right now, I'm opening this PR to fix and update the package as it is, but if I have some extra time, I will try and fix that bug because I need it to work for a project of mine too.

